### PR TITLE
Fix #39: Lottery animation occludes confirm button

### DIFF
--- a/src/components/layouts/HeaderLotteryCardDialog.vue
+++ b/src/components/layouts/HeaderLotteryCardDialog.vue
@@ -610,7 +610,7 @@ export default {
           line-height: 24px;
           background-position: center;
           background-size: contain;
-          z-index: 2;
+          z-index: 1;
           font-weight: 800;
           cursor: pointer;
           animation: fade-in 4s forwards;

--- a/src/components/layouts/HeaderLotteryCardDialog.vue
+++ b/src/components/layouts/HeaderLotteryCardDialog.vue
@@ -610,6 +610,7 @@ export default {
           line-height: 24px;
           background-position: center;
           background-size: contain;
+          z-index: 2;
           font-weight: 800;
           cursor: pointer;
           animation: fade-in 4s forwards;


### PR DESCRIPTION
This is a simple fix to issue #39 where the div `lottery-bg-3-animation` has a z-index of 1 and hence occludes the `lottery-dialog-confirm-count` button which has no `z-index` set.
This simple change sets the `z-index` to 1, preventing the occlusion of the confirm button (on firefox browsers)